### PR TITLE
Add 250Hz aiming and motor command threads with EMA smoothing

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,10 +7,12 @@
 
 package frc.robot;
 
+import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Kilograms;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Pounds;
+import static edu.wpi.first.units.Units.RPM;
 import static frc.robot.subsystems.vision.VisionConstants.backLeftCamera;
 import static frc.robot.subsystems.vision.VisionConstants.frontLeftCamera;
 import static frc.robot.subsystems.vision.VisionConstants.frontLeftForwardCamera;
@@ -23,6 +25,7 @@ import static frc.robot.subsystems.vision.VisionConstants.robotToFrontRightCamer
 
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.SignalLogger;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -37,6 +40,7 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.robot.aiming.AimingBehavior;
+import frc.robot.aiming.AimingConstants;
 import frc.robot.aiming.AimingService;
 import frc.robot.commands.DriveCommands;
 import frc.robot.generated.TunerConstants;
@@ -88,6 +92,7 @@ import frc.robot.subsystems.vision.VisionIOPhotonVisionSim;
 import frc.robot.subsystems.vision.VisionIOQuest;
 import frc.robot.util.AllEvents;
 import frc.robot.util.GoalBehavior;
+import frc.robot.util.HighFrequencyLoop;
 import frc.robot.util.LoggedTunableNumber;
 import frc.robot.util.SubsystemBehavior;
 import org.ironmaple.simulation.SimulatedArena;
@@ -176,8 +181,7 @@ public class RobotContainer {
                 new ModuleIOTalonFX(TunerConstants.BackLeft),
                 new ModuleIOTalonFX(TunerConstants.BackRight),
                 (robotPose) -> {});
-        aimingService =
-            new AimingService(drive::getAutoAlignPose, drive::getChassisSpeeds, drive::getRotation);
+        aimingService = new AimingService(drive::getLatestSnapshot);
         driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose);
         intake = new IntakeSubsystem(new IntakeIOTalonFX(1, 2, 3, upperCanbus));
         climber = new ClimberSubsystem(new ClimberIO() {}); // TODO: Implement Climber
@@ -243,8 +247,7 @@ public class RobotContainer {
                 new VisionIOPhotonVisionSim(
                     frontLeftForwardCamera, robotToFrontLeftForwardCamera, drive::getPose),
                 new VisionIOPhotonVisionSim(backLeftCamera, robotToBackLeftCamera, drive::getPose));
-        aimingService =
-            new AimingService(drive::getPose, drive::getChassisSpeeds, drive::getRotation);
+        aimingService = new AimingService(drive::getLatestSnapshot);
         driveZoneTracker = new DriveZoneTracker(drive::getPose);
         intake = new IntakeSubsystem(new IntakeIOSim());
         indexer = new IndexerSubsystem(new IndexerIOSim());
@@ -283,8 +286,7 @@ public class RobotContainer {
                 drive::addVisionMeasurementAutoAlign,
                 new VisionIO() {},
                 new VisionIO() {});
-        aimingService =
-            new AimingService(drive::getAutoAlignPose, drive::getChassisSpeeds, drive::getRotation);
+        aimingService = new AimingService(drive::getLatestSnapshot);
         driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose);
         intake = new IntakeSubsystem(new IntakeIO() {});
         indexer = new IndexerSubsystem(new IndexerIO() {});
@@ -293,6 +295,48 @@ public class RobotContainer {
         turret = new TurretSubsystem(new TurretIO() {}, aimingService::getTurretAngleDeg);
         hood = new HoodSubsystem(new HoodIO() {}, aimingService::getHoodAngleDeg);
         break;
+    }
+
+    // Start 250Hz control threads for REAL and SIM (not REPLAY)
+    if (Constants.currentMode != Constants.Mode.REPLAY) {
+      double freq = AimingConstants.AIMING_FREQUENCY;
+
+      new HighFrequencyLoop("AimingThread", freq, aimingService::computeAimingSolution).start();
+
+      new HighFrequencyLoop(
+              "TurretThread",
+              freq,
+              () -> {
+                if (turret.shouldThreadCommand()) {
+                  double angle = MathUtil.clamp(aimingService.getTurretAngleDeg(), -180.0, 180.0);
+                  turret.getIO().setTarget(angle);
+                }
+              })
+          .start();
+
+      new HighFrequencyLoop(
+              "ShooterThread",
+              freq,
+              () -> {
+                if (shooter.shouldThreadCommand()) {
+                  double rpm = aimingService.getShooterRPM();
+                  if (rpm < AimingConstants.SHOOTER_MIN_RPM) {
+                    rpm = shooter.getPrespinSetpoint();
+                  }
+                  shooter.getIO().setShooterTarget(RPM.of(rpm));
+                }
+              })
+          .start();
+
+      new HighFrequencyLoop(
+              "HoodThread",
+              freq,
+              () -> {
+                if (hood.shouldThreadCommand()) {
+                  hood.getIO().setHoodTarget(Degrees.of(aimingService.getHoodAngleDeg()));
+                }
+              })
+          .start();
     }
 
     autoCommandManager = new AutoCommandManager(drive, RobotGoals.getInstance());

--- a/src/main/java/frc/robot/aiming/AimingConstants.java
+++ b/src/main/java/frc/robot/aiming/AimingConstants.java
@@ -73,4 +73,8 @@ public final class AimingConstants {
   // ===== VELOCITY COMPENSATION =====
   // Minimum ball radial speed before solution is considered invalid (m/s)
   public static final double MIN_BALL_RADIAL_SPEED = 0.5;
+
+  // ===== HIGH-FREQUENCY LOOP =====
+  // Frequency for aiming computation and motor command threads (Hz)
+  public static final double AIMING_FREQUENCY = 250.0;
 }

--- a/src/main/java/frc/robot/aiming/AimingService.java
+++ b/src/main/java/frc/robot/aiming/AimingService.java
@@ -8,45 +8,64 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.FieldConstants;
+import frc.robot.subsystems.drive.PoseSnapshot;
 import frc.robot.util.EnumState;
+import frc.robot.util.LoggedTunableNumber;
 import frc.robot.util.VirtualSubsystem;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
 
 /**
- * Central aiming service that computes turret angle, hood angle, and shooter RPM every cycle.
- * Performs velocity-space compensation to account for robot motion while shooting.
+ * Central aiming service that computes turret angle, hood angle, and shooter RPM. Computation runs
+ * at 250Hz via AimingThread; logging and visualization run at 50Hz via periodic().
  */
 public class AimingService extends VirtualSubsystem implements AimingEvents {
 
-  private final Supplier<Pose2d> robotPoseSupplier;
-  private final Supplier<ChassisSpeeds> chassisSpeedsSupplier;
-  private final Supplier<Rotation2d> robotHeadingSupplier;
+  private final Supplier<PoseSnapshot> snapshotSupplier;
 
   private final EnumState<AimingTarget> targetState =
       new EnumState<>("Aiming/Target", AimingTarget.HUB);
 
-  private double turretAngleDeg = 0.0;
-  private double hoodAngleDeg = 45.0;
-  private double shooterRPM = 0.0;
-  private double distanceToTargetM = 0.0;
-  private boolean solutionValid = false;
+  // Thread-safe mirror of targetState (EnumState.currentState is not volatile)
+  private volatile AimingTarget currentTarget = AimingTarget.HUB;
+
+  // Volatile outputs written by computeAimingSolution() at 250Hz
+  private volatile double turretAngleDeg = 0.0;
+  private volatile double hoodAngleDeg = 45.0;
+  private volatile double shooterRPM = 0.0;
+  private volatile double distanceToTargetM = 0.0;
+  private volatile boolean solutionValid = false;
+
+  // Cached launcher params for BallTrajectorySim at 50Hz
+  private volatile double cachedLauncherSpeed = 0.0;
+  private volatile double cachedLauncherAngleRad = 0.0;
+
+  // EMA smoothing — alpha in (0, 1]. Lower = smoother, 1.0 = no filtering.
+  private static final LoggedTunableNumber rpmEmaAlpha =
+      new LoggedTunableNumber("Aiming/Smoothing/rpmEmaAlpha", 0.08);
+  private static final LoggedTunableNumber turretEmaAlpha =
+      new LoggedTunableNumber("Aiming/Smoothing/turretEmaAlpha", 0.15);
+  private static final LoggedTunableNumber hoodEmaAlpha =
+      new LoggedTunableNumber("Aiming/Smoothing/hoodEmaAlpha", 0.10);
+
+  // EMA state (only written by AimingThread, no synchronization needed)
+  private double smoothedRPM = 0.0;
+  private double smoothedTurretDeg = 0.0;
+  private double smoothedHoodDeg = 0.0;
+  private boolean emaInitialized = false;
 
   private final BallTrajectorySim trajectorySim = new BallTrajectorySim();
 
-  public AimingService(
-      Supplier<Pose2d> robotPoseSupplier,
-      Supplier<ChassisSpeeds> chassisSpeedsSupplier,
-      Supplier<Rotation2d> robotHeadingSupplier) {
-    this.robotPoseSupplier = robotPoseSupplier;
-    this.chassisSpeedsSupplier = chassisSpeedsSupplier;
-    this.robotHeadingSupplier = robotHeadingSupplier;
+  public AimingService(Supplier<PoseSnapshot> snapshotSupplier) {
+    this.snapshotSupplier = snapshotSupplier;
   }
 
   public void setTarget(AimingTarget target) {
     targetState.set(target);
+    currentTarget = target;
   }
 
   @Override
@@ -64,12 +83,60 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
     return targetState.is(AimingTarget.PASS_HIGH);
   }
 
+  /** Called at 250Hz by AimingThread. Reads snapshot, extrapolates pose, computes solution. */
+  public void computeAimingSolution() {
+    PoseSnapshot snapshot = snapshotSupplier.get();
+
+    // Linear extrapolation: estimate current pose using velocity * dt
+    double now = Timer.getFPGATimestamp();
+    double dt = MathUtil.clamp(now - snapshot.timestampSeconds(), 0.0, 0.1);
+
+    ChassisSpeeds speeds = snapshot.chassisSpeeds();
+    Rotation2d heading = snapshot.heading();
+
+    // Field-relative velocity for extrapolation
+    double cos = heading.getCos();
+    double sin = heading.getSin();
+    double vxField = speeds.vxMetersPerSecond * cos - speeds.vyMetersPerSecond * sin;
+    double vyField = speeds.vxMetersPerSecond * sin + speeds.vyMetersPerSecond * cos;
+
+    Pose2d basePose = snapshot.pose();
+    Pose2d robotPose =
+        new Pose2d(
+            basePose.getX() + vxField * dt,
+            basePose.getY() + vyField * dt,
+            basePose.getRotation().plus(Rotation2d.fromRadians(speeds.omegaRadiansPerSecond * dt)));
+    Rotation2d extrapolatedHeading = robotPose.getRotation();
+
+    // Compute the aiming solution using extrapolated pose
+    computeForPose(robotPose, speeds, extrapolatedHeading);
+  }
+
+  /** 50Hz logging and visualization only. Reads volatile fields. */
   @Override
   public void periodic() {
-    Pose2d robotPose = robotPoseSupplier.get();
-    ChassisSpeeds speeds = chassisSpeedsSupplier.get();
-    Rotation2d heading = robotHeadingSupplier.get();
+    targetState.log();
+    logOutputs();
 
+    // Trajectory visualization at 50Hz using cached launcher params
+    PoseSnapshot snapshot = snapshotSupplier.get();
+    if (solutionValid) {
+      Rotation2d heading = snapshot.heading();
+      Translation2d turretFieldPos = computeTurretFieldPosition(snapshot.pose(), heading);
+      double fieldTurretYaw = heading.getRadians() + Math.PI + Math.toRadians(turretAngleDeg);
+      Translation2d turretVelocity = computeTurretVelocity(snapshot.chassisSpeeds(), heading);
+      trajectorySim.simulate(
+          turretFieldPos,
+          fieldTurretYaw,
+          cachedLauncherAngleRad,
+          cachedLauncherSpeed,
+          turretVelocity);
+    } else {
+      trajectorySim.publishEmpty();
+    }
+  }
+
+  private void computeForPose(Pose2d robotPose, ChassisSpeeds speeds, Rotation2d heading) {
     Translation3d target = getTargetPosition();
     Translation2d turretFieldPos = computeTurretFieldPosition(robotPose, heading);
 
@@ -94,41 +161,27 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
     double vRadial = turretVelocity.getX() * ux + turretVelocity.getY() * uy;
     double vTangential = -turretVelocity.getX() * uy + turretVelocity.getY() * ux;
 
-    // Compute field-frame trajectory: pick a desired launch angle, compute the exact speed
-    // needed to hit the target at that angle. Ball arrives descending for angles above ~45 deg.
-    // Formula: v = (x / cos(theta)) * sqrt(g / (2 * (x*tan(theta) - y)))
     double fieldLaunchAngle = Math.toRadians(AimingConstants.TARGET_LAUNCH_ANGLE_DEG.get());
     double tanTheta = Math.tan(fieldLaunchAngle);
     double cosTheta = Math.cos(fieldLaunchAngle);
     double denominator = horizontalDistance * tanTheta - verticalDistance;
 
     if (denominator <= 0) {
-      // Target is too close or angle too shallow to reach the height
       solutionValid = false;
-      logOutputs();
-      trajectorySim.publishEmpty();
       return;
     }
 
     double fieldTotalSpeed =
         (horizontalDistance / cosTheta) * Math.sqrt(AimingConstants.GRAVITY / (2.0 * denominator));
 
-    // Compute launcher exit velocity (compensate for both radial and tangential turret velocity).
-    // The launcher must provide a horizontal velocity that, combined with the turret's velocity,
-    // gives exactly fieldHorizontal toward the target and zero tangential drift.
     double fieldHorizontal = fieldTotalSpeed * Math.cos(fieldLaunchAngle);
     double fieldVertical = fieldTotalSpeed * Math.sin(fieldLaunchAngle);
 
-    // Solve the two constraints simultaneously:
-    //   launcherH * cos(yawCorr) + vRadial     = fieldHorizontal  (radial)
-    //   launcherH * sin(yawCorr) + vTangential  = 0               (tangential)
     double launcherRadial = fieldHorizontal - vRadial;
     double launcherTangential = -vTangential;
 
     if (launcherRadial <= AimingConstants.MIN_BALL_RADIAL_SPEED) {
       solutionValid = false;
-      logOutputs();
-      trajectorySim.publishEmpty();
       return;
     }
 
@@ -158,31 +211,43 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
 
     solutionValid = turretInRange && hoodInRange && rpmInRange;
 
-    turretAngleDeg =
+    double clampedTurret =
         MathUtil.clamp(
             compensatedTurretDeg, AimingConstants.TURRET_MIN_DEG, AimingConstants.TURRET_MAX_DEG);
-    hoodAngleDeg =
+    double clampedHood =
         MathUtil.clamp(
             launcherAngleDeg, AimingConstants.HOOD_MIN_DEG, AimingConstants.HOOD_MAX_DEG);
-    shooterRPM =
+    double clampedRPM =
         MathUtil.clamp(rpm, AimingConstants.SHOOTER_MIN_RPM, AimingConstants.SHOOTER_MAX_RPM);
 
-    // Trajectory visualization (launcher exit speed + turret velocity = field trajectory)
-    double fieldTurretYaw = heading.getRadians() + Math.toRadians(turretAngleDeg);
-    trajectorySim.simulate(
-        turretFieldPos, fieldTurretYaw, launcherAngleRad, launcherSpeed, turretVelocity);
+    // EMA smoothing to reduce high-frequency noise from pose estimation
+    if (!emaInitialized) {
+      smoothedTurretDeg = clampedTurret;
+      smoothedHoodDeg = clampedHood;
+      smoothedRPM = clampedRPM;
+      emaInitialized = true;
+    } else {
+      double aT = turretEmaAlpha.get();
+      double aH = hoodEmaAlpha.get();
+      double aR = rpmEmaAlpha.get();
+      smoothedTurretDeg = aT * clampedTurret + (1.0 - aT) * smoothedTurretDeg;
+      smoothedHoodDeg = aH * clampedHood + (1.0 - aH) * smoothedHoodDeg;
+      smoothedRPM = aR * clampedRPM + (1.0 - aR) * smoothedRPM;
+    }
 
-    logOutputs();
+    turretAngleDeg = smoothedTurretDeg;
+    hoodAngleDeg = smoothedHoodDeg;
+    shooterRPM = smoothedRPM;
+
+    // Cache launcher params for 50Hz trajectory visualization
+    cachedLauncherSpeed = launcherSpeed;
+    cachedLauncherAngleRad = launcherAngleRad;
   }
 
-  /**
-   * Get the correct target position based on aiming target state and alliance color. For HUB,
-   * targets the top rim so the ball arcs over and drops in. Pass targets are at ground level.
-   */
   private Translation3d getTargetPosition() {
     boolean isRed = DriverStation.getAlliance().orElse(Alliance.Blue) == Alliance.Red;
 
-    switch (targetState.get()) {
+    switch (currentTarget) {
       case PASS_LOW:
         Translation2d lowPass =
             isRed ? AimingConstants.LOW_RED_PASS : AimingConstants.LOW_BLUE_PASS;
@@ -197,24 +262,17 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
     }
   }
 
-  /** Compute the turret pivot position in field coordinates. */
   private Translation2d computeTurretFieldPosition(Pose2d robotPose, Rotation2d heading) {
     Translation2d rotatedOffset = AimingConstants.TURRET_OFFSET_FROM_CENTER.rotateBy(heading);
     return robotPose.getTranslation().plus(rotatedOffset);
   }
 
-  /**
-   * Compute the velocity of the turret pivot in field-frame. turretVelocity =
-   * robotLinearVelocity_field + omega x turretOffset_field
-   */
   private Translation2d computeTurretVelocity(ChassisSpeeds speeds, Rotation2d heading) {
-    // Convert robot-relative chassis speeds to field-relative
     double cos = heading.getCos();
     double sin = heading.getSin();
     double vxField = speeds.vxMetersPerSecond * cos - speeds.vyMetersPerSecond * sin;
     double vyField = speeds.vxMetersPerSecond * sin + speeds.vyMetersPerSecond * cos;
 
-    // Rotational contribution at turret offset: omega x r (2D cross product)
     Translation2d rotatedOffset = AimingConstants.TURRET_OFFSET_FROM_CENTER.rotateBy(heading);
     double omega = speeds.omegaRadiansPerSecond;
     double vxRot = -omega * rotatedOffset.getY();
@@ -229,7 +287,8 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
     Logger.recordOutput("Aiming/ShooterRPM", shooterRPM);
     Logger.recordOutput("Aiming/DistanceToTargetM", distanceToTargetM);
     Logger.recordOutput("Aiming/SolutionValid", solutionValid);
-    Logger.recordOutput("Aiming/RobotPose", robotPoseSupplier.get());
+    PoseSnapshot snapshot = snapshotSupplier.get();
+    Logger.recordOutput("Aiming/RobotPose", snapshot.pose());
     Logger.recordOutput("Aiming/TargetPosition", getTargetPosition());
   }
 

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -134,6 +134,7 @@ public class Drive extends SubsystemBase {
 
   private SwerveDrivePoseEstimator poseEstimatorAutoAlign =
       new SwerveDrivePoseEstimator(kinematics, rawGyroRotation, lastModulePositions, new Pose2d());
+  private volatile PoseSnapshot latestSnapshot = PoseSnapshot.IDENTITY;
   private final Consumer<Pose2d> resetSimulationPoseCallBack;
   private final Field2d ppField2d = new Field2d();
   private final Field2d robotField2d = new Field2d();
@@ -255,6 +256,18 @@ public class Drive extends SubsystemBase {
 
     // Update gyro alert
     gyroDisconnectedAlert.set(!gyroInputs.connected && Constants.currentMode != Mode.SIM);
+
+    // Publish snapshot for high-frequency aiming thread
+    latestSnapshot =
+        new PoseSnapshot(
+            getPose(),
+            getChassisSpeeds(),
+            getRotation(),
+            edu.wpi.first.wpilibj.Timer.getFPGATimestamp());
+  }
+
+  public PoseSnapshot getLatestSnapshot() {
+    return latestSnapshot;
   }
 
   public static AprilTagFieldLayout getAprilTagLayout() {

--- a/src/main/java/frc/robot/subsystems/drive/PoseSnapshot.java
+++ b/src/main/java/frc/robot/subsystems/drive/PoseSnapshot.java
@@ -1,0 +1,17 @@
+package frc.robot.subsystems.drive;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+
+/**
+ * Immutable snapshot of drive state, published by Drive.periodic() at 50Hz and consumed by the
+ * aiming thread at 250Hz. Since records are immutable and the reference is volatile, reading is
+ * always consistent without locks.
+ */
+public record PoseSnapshot(
+    Pose2d pose, ChassisSpeeds chassisSpeeds, Rotation2d heading, double timestampSeconds) {
+
+  public static final PoseSnapshot IDENTITY =
+      new PoseSnapshot(new Pose2d(), new ChassisSpeeds(), Rotation2d.kZero, 0.0);
+}

--- a/src/main/java/frc/robot/subsystems/hood/HoodSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/hood/HoodSubsystem.java
@@ -18,7 +18,8 @@ public class HoodSubsystem extends SubsystemBase implements HoodEvents {
   private LoggedTunableNumber aimAngle = new LoggedTunableNumber("Hood/aimAngle", 45);
   private LoggedTunableNumber passAngle = new LoggedTunableNumber("Hood/passAngle", 22.5);
 
-  private HoodIO m_IO;
+  private final HoodIO m_IO;
+  private volatile boolean shouldThreadCommand = false;
 
   private final EnumState<HoodState> currentGoal = new EnumState<>("Hood/States", HoodState.IDLE);
 
@@ -72,19 +73,27 @@ public class HoodSubsystem extends SubsystemBase implements HoodEvents {
   public void periodic() {
     m_IO.updateInputs(logged);
     Logger.processInputs("RobotState/Hood", logged);
-    switch (currentGoal.get()) {
+    HoodState state = currentGoal.get();
+    shouldThreadCommand = (state == HoodState.AIMING);
+    switch (state) {
       case IDLE:
         m_IO.stop();
         break;
       case AIMING:
-        // TODO these are filler units
-        m_IO.setHoodTarget(Degrees.of(hoodAngleSupplier.getAsDouble()));
-        break;
+        break; // 250Hz thread handles motor commands
       case PASSING:
-        m_IO.setHoodTarget(Degrees.of(passAngle.get())); // Example pass angle
+        m_IO.setHoodTarget(Degrees.of(passAngle.get()));
         break;
     }
     tunableGains.ifGainsHaveChanged((gains) -> this.m_IO.setGains(gains));
+  }
+
+  public boolean shouldThreadCommand() {
+    return shouldThreadCommand;
+  }
+
+  public HoodIO getIO() {
+    return m_IO;
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -9,7 +9,6 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.aiming.AimingConstants;
 import frc.robot.util.EnumState;
 import frc.robot.util.LoggedTunableGainsBuilder;
 import frc.robot.util.LoggedTunableNumber;
@@ -17,8 +16,9 @@ import java.util.function.DoubleSupplier;
 import org.littletonrobotics.junction.Logger;
 
 public class ShooterSubsystem extends SubsystemBase implements ShooterEvents {
-  private ShooterIO m_IO;
-  private LoggedTunableNumber setpoint = new LoggedTunableNumber("Shooter/setpoint", 2500);
+  private final ShooterIO m_IO;
+  private final LoggedTunableNumber setpoint = new LoggedTunableNumber("Shooter/setpoint", 2500);
+  private volatile boolean shouldThreadCommand = false;
 
   private final EnumState<ShooterState> m_state =
       new EnumState<>("Shooter/States", ShooterState.PRESPIN);
@@ -84,20 +84,29 @@ public class ShooterSubsystem extends SubsystemBase implements ShooterEvents {
   public void periodic() {
     m_IO.updateInputs(logged);
     Logger.processInputs("RobotState/Shooter", logged);
-    switch (m_state.get()) {
+    ShooterState state = m_state.get();
+    shouldThreadCommand = (state == ShooterState.SHOOTING || state == ShooterState.PRESPIN);
+    switch (state) {
       case SHOOTING:
       case PRESPIN:
-        double rpm = shooterRPMSupplier.getAsDouble();
-        if (rpm < AimingConstants.SHOOTER_MIN_RPM) {
-          rpm = setpoint.get();
-        }
-        setShooterSpeed(RPM.of(rpm));
-        break;
+        break; // 250Hz thread handles motor commands
       case IDLE:
         stop();
         break;
     }
     tunableGains.ifGainsHaveChanged((gains) -> this.m_IO.setGains(gains));
+  }
+
+  public boolean shouldThreadCommand() {
+    return shouldThreadCommand;
+  }
+
+  public ShooterIO getIO() {
+    return m_IO;
+  }
+
+  public double getPrespinSetpoint() {
+    return setpoint.get();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/turret/TurretIOSim.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretIOSim.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import frc.robot.util.Gains;
 
 public class TurretIOSim implements TurretIO {
-  private Angle turretAppliedAngle = Degrees.mutable(0.0);
+  private volatile Angle turretAppliedAngle = Degrees.mutable(0.0);
 
   private final SingleJointedArmSim turretSim;
   private ArmFeedforward ff = new ArmFeedforward(0.0, 0.0, 0.0, 0.0);

--- a/src/main/java/frc/robot/subsystems/turret/TurretIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretIOTalonFX.java
@@ -13,6 +13,7 @@ import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.units.measure.Angle;
+import frc.robot.aiming.AimingConstants;
 import frc.robot.util.Gains;
 import frc.robot.util.PhoenixUtil;
 import org.littletonrobotics.junction.Logger;
@@ -95,6 +96,11 @@ public class TurretIOTalonFX implements TurretIO {
         calculateTurretAngleFromCANCoderDegrees(
             getCanCoderAngle1().in(Degrees), getCanCoderAngle2().in(Degrees));
     motor.setPosition(startAngle, KCANTIMEOUT);
+
+    // High-frequency signal updates for 250Hz turret thread
+    motor.getPosition().setUpdateFrequency(AimingConstants.AIMING_FREQUENCY);
+    motor.getVelocity().setUpdateFrequency(AimingConstants.AIMING_FREQUENCY);
+    motor.optimizeBusUtilization();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/turret/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretSubsystem.java
@@ -21,7 +21,8 @@ public class TurretSubsystem extends SubsystemBase implements TurretEvents {
 
   private LoggedTunableNumber IdleAngle = new LoggedTunableNumber("Turret/IdleAngle", 10);
 
-  private TurretIO m_IO;
+  private final TurretIO m_IO;
+  private volatile boolean shouldThreadCommand = false;
 
   private final EnumState<TurretState> m_state =
       new EnumState<>("Turret/States", TurretState.AIMING);
@@ -99,16 +100,25 @@ public class TurretSubsystem extends SubsystemBase implements TurretEvents {
   public void periodic() {
     m_IO.updateInputs(logged);
     Logger.processInputs("RobotState/Turret", logged);
-    switch (m_state.get()) {
+    TurretState state = m_state.get();
+    shouldThreadCommand = (state == TurretState.AIMING || state == TurretState.PASSING);
+    switch (state) {
       case AIMING:
       case PASSING:
-        setPosition(turretAngleSupplier.getAsDouble());
-        break;
+        break; // 250Hz thread handles motor commands
       case IDLE:
         setPosition(IdleAngle.get());
         break;
     }
     tunableGains.ifGainsHaveChanged((gains) -> this.m_IO.setGains(gains));
+  }
+
+  public boolean shouldThreadCommand() {
+    return shouldThreadCommand;
+  }
+
+  public TurretIO getIO() {
+    return m_IO;
   }
 
   @Override

--- a/src/main/java/frc/robot/util/HighFrequencyLoop.java
+++ b/src/main/java/frc/robot/util/HighFrequencyLoop.java
@@ -1,0 +1,30 @@
+package frc.robot.util;
+
+/**
+ * Generic reusable daemon thread for running a task at a specified frequency. Used for 250Hz aiming
+ * computation and motor commands. Modeled after PhoenixOdometryThread's daemon pattern.
+ */
+public class HighFrequencyLoop extends Thread {
+
+  private final Runnable task;
+  private final double frequencyHz;
+
+  public HighFrequencyLoop(String name, double frequencyHz, Runnable task) {
+    setName(name);
+    setDaemon(true);
+    this.task = task;
+    this.frequencyHz = frequencyHz;
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        Thread.sleep((long) (1000.0 / frequencyHz));
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      task.run();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Run AimingService ballistics at 250Hz (up from 50Hz) with pose extrapolation via `PoseSnapshot` for sub-4ms freshness
- Command turret, hood, and shooter motors at 250Hz via independent `HighFrequencyLoop` daemon threads
- Add EMA smoothing on all three outputs (RPM, turret angle, hood angle) with tunable alpha values under `Aiming/Smoothing/` to reduce pose estimation noise
- 50Hz main loop now only handles logging, visualization, and state management

## Thread Safety
| Data | Writer | Reader | Mechanism |
|------|--------|--------|-----------|
| PoseSnapshot | Drive 50Hz | AimingThread 250Hz | volatile ref to immutable record |
| turretAngleDeg, hoodAngleDeg, shooterRPM | AimingThread 250Hz | Motor threads 250Hz + main 50Hz | volatile double |
| shouldThreadCommand (per subsystem) | Main thread periodic | Motor threads 250Hz | volatile boolean |
| TalonFX.setControl() | Motor threads 250Hz | CTRE internal | Thread-safe per CTRE docs |

## Test plan
- [ ] `./gradlew build` compiles and passes Spotless
- [ ] Simulation: aiming outputs update, turret/hood/shooter track targets, no thread crashes
- [ ] AdvantageKit logs: `Aiming/ShooterRPM`, `Aiming/TurretAngleDeg`, `Aiming/HoodAngleDeg` still logged at 50Hz
- [ ] Tune EMA alpha values in SmartDashboard under `Aiming/Smoothing/` and verify smoothing behavior
- [ ] Verify motor commands reach hardware within ~4ms instead of 20ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)