### PR TITLE
Add reactive drive speed limiter for intaking and shooting

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,6 +53,7 @@ import frc.robot.subsystems.climber.ClimberIO;
 import frc.robot.subsystems.climber.ClimberIOSim;
 import frc.robot.subsystems.climber.ClimberSubsystem;
 import frc.robot.subsystems.drive.Drive;
+import frc.robot.subsystems.drive.DriveBehavior;
 import frc.robot.subsystems.drive.DriveZoneTracker;
 import frc.robot.subsystems.drive.GyroIO;
 import frc.robot.subsystems.drive.GyroIOPigeon2;
@@ -120,7 +121,6 @@ public class RobotContainer {
   private final Drive drive;
   public static final SwerveDriveSimulation driveSimulation =
       new SwerveDriveSimulation(Drive.mapleSimConfig, new Pose2d(3, 3, new Rotation2d()));
-  ;
 
   private final double REG_DRIVE_SPEED = 0.9;
   private final double REG_ANGULAR_SPEED = 0.75;
@@ -361,6 +361,7 @@ public class RobotContainer {
 
     // Create goal behaviors (wires operator intent → robot goals)
     new RobotGoalsBehavior(robotGoals);
+    new DriveBehavior(drive);
     new IndexerBehavior(indexer);
     new IntakeBehavior(intake);
     new ShooterBehavior(shooter);
@@ -405,33 +406,25 @@ public class RobotContainer {
             ? () -> drive.setPose(driveSimulation.getSimulatedDriveTrainPose())
             : () -> drive.setPose(new Pose2d(drive.getPose().getTranslation(), new Rotation2d()));
 
-    // Default command - auto-test pattern (no controller needed)
-    // To restore normal driving, uncomment joystickDrive and comment out autoDriveTest
-    // drive.setDefaultCommand(DriveCommands.autoDriveTest(drive));
+    // Effective speed limit = min(operator slow button, goal-based limit from DriveBehavior)
+    drive.setOperatorSpeedLimit(REG_DRIVE_SPEED);
     drive.setDefaultCommand(
         DriveCommands.joystickDrive(
             drive,
-            () -> -controller.getLeftY() * REG_DRIVE_SPEED,
-            () -> -controller.getLeftX() * REG_DRIVE_SPEED,
+            () -> -controller.getLeftY() * drive.getEffectiveSpeedLimit(),
+            () -> -controller.getLeftX() * drive.getEffectiveSpeedLimit(),
             () -> -controller.getRightX() * REG_ANGULAR_SPEED));
 
     // Switch to X pattern when X button is pressed
     controller.x().onTrue(Commands.runOnce(drive::stopWithX, drive));
 
+    // Slow button sets operator speed limit directly
     controller
         .leftTrigger()
         .whileTrue(
-            DriveCommands.joystickDrive(
-                drive,
-                () -> -controller.getLeftY() * SLOW_DRIVE_SPEED,
-                () -> -controller.getLeftX() * SLOW_DRIVE_SPEED,
-                () -> -controller.getRightX() * REG_ANGULAR_SPEED))
-        .whileFalse(
-            DriveCommands.joystickDrive(
-                drive,
-                () -> -controller.getLeftY() * REG_DRIVE_SPEED,
-                () -> -controller.getLeftX() * REG_DRIVE_SPEED,
-                () -> -controller.getRightX() * REG_ANGULAR_SPEED));
+            Commands.startEnd(
+                () -> drive.setOperatorSpeedLimit(SLOW_DRIVE_SPEED),
+                () -> drive.setOperatorSpeedLimit(REG_DRIVE_SPEED)));
 
     // Maple-Sim Button Bindings
     // // Spawns Fuel

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -138,6 +138,10 @@ public class Drive extends SubsystemBase {
       new SwerveDrivePoseEstimator(kinematics, rawGyroRotation, lastModulePositions, new Pose2d());
   private volatile PoseSnapshot latestSnapshot = PoseSnapshot.IDENTITY;
   private final Consumer<Pose2d> resetSimulationPoseCallBack;
+
+  // Speed limiting: effective limit is min(operator, goal)
+  private double operatorSpeedLimit = 1.0;
+  private double goalSpeedLimit = 1.0;
   private final Field2d ppField2d = new Field2d();
   private final Field2d robotField2d = new Field2d();
 
@@ -444,6 +448,21 @@ public class Drive extends SubsystemBase {
     addVisionMeasurement(visionRobotPoseMeters, timestampSeconds, visionMeasurementStdDevs, false);
     addVisionMeasurementAutoAlign(
         visionRobotPoseMeters, timestampSeconds, visionMeasurementStdDevs, false);
+  }
+
+  public void setOperatorSpeedLimit(double limit) {
+    this.operatorSpeedLimit = limit;
+    Logger.recordOutput("Drive/OperatorSpeedLimit", limit);
+  }
+
+  public void setGoalSpeedLimit(double limit) {
+    this.goalSpeedLimit = limit;
+    Logger.recordOutput("Drive/GoalSpeedLimit", limit);
+  }
+
+  @AutoLogOutput(key = "Drive/EffectiveSpeedLimit")
+  public double getEffectiveSpeedLimit() {
+    return Math.min(operatorSpeedLimit, goalSpeedLimit);
   }
 
   /** Returns the maximum linear speed in meters per sec. */

--- a/src/main/java/frc/robot/subsystems/drive/DriveBehavior.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveBehavior.java
@@ -1,0 +1,41 @@
+package frc.robot.subsystems.drive;
+
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.util.AllEvents;
+import frc.robot.util.LoggedTunableNumber;
+import frc.robot.util.SubsystemBehavior;
+
+public class DriveBehavior extends SubsystemBehavior {
+  private static final double NO_SPEED_LIMIT = 1.0;
+
+  private final LoggedTunableNumber intakingSpeedLimit =
+      new LoggedTunableNumber("Drive/IntakingSpeedLimit", 0.6);
+  private final LoggedTunableNumber shootingSpeedLimit =
+      new LoggedTunableNumber("Drive/ShootingSpeedLimit", 0.5);
+
+  private final Drive drive;
+
+  public DriveBehavior(Drive drive) {
+    this.drive = drive;
+  }
+
+  @Override
+  public void configure(AllEvents events) {
+    events
+        .goals()
+        .isIntakingTrigger()
+        .whileTrue(
+            Commands.startEnd(
+                () -> drive.setGoalSpeedLimit(intakingSpeedLimit.get()),
+                () -> drive.setGoalSpeedLimit(NO_SPEED_LIMIT)));
+
+    events
+        .goals()
+        .isShootingTrigger()
+        .or(events.goals().isPassingTrigger())
+        .whileTrue(
+            Commands.startEnd(
+                () -> drive.setGoalSpeedLimit(shootingSpeedLimit.get()),
+                () -> drive.setGoalSpeedLimit(NO_SPEED_LIMIT)));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `DriveBehavior` (new `SubsystemBehavior`) that reactively limits drive speed based on robot goals
- Speed is limited to 60% while intaking and 50% while shooting/passing, both tunable via LoggedTunableNumber
- Two independent speed limit sources (operator slow button + goal-based) composed via `Math.min()` in `Drive`
- Simplifies `RobotContainer` drive command setup

## Test plan
- [ ] Verify drive speed reduces when intaking
- [ ] Verify drive speed reduces when shooting or passing
- [ ] Verify slow button (left trigger) still works independently
- [ ] Verify both limits compose correctly (e.g., slow button during intaking uses lowest limit)
- [ ] Verify speed returns to normal when goals change back to IDLE
- [ ] Tune speed limit values via SmartDashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)