### PR TITLE
Add far-distance launch angle for hub shots

### DIFF
--- a/src/main/java/frc/robot/aiming/AimingConstants.java
+++ b/src/main/java/frc/robot/aiming/AimingConstants.java
@@ -64,6 +64,12 @@ public final class AimingConstants {
   // targets).
   public static final LoggedTunableNumber TARGET_LAUNCH_ANGLE_DEG =
       new LoggedTunableNumber("Aiming/targetLaunchAngleDeg", 71.0);
+  public static final LoggedTunableNumber TARGET_FAR_LAUNCH_ANGLE_DEG =
+      new LoggedTunableNumber("Aiming/targetFarLaunchAngleDeg", 65.0);
+  public static final LoggedTunableNumber FAR_DISTANCE_THRESHOLD_M =
+      new LoggedTunableNumber("Aiming/farDistanceThresholdM", 3.5);
+  public static final LoggedTunableNumber FAR_DISTANCE_HYSTERESIS_M =
+      new LoggedTunableNumber("Aiming/farDistanceHysteresisM", 0.3);
   public static final LoggedTunableNumber TARGET_PASS_LAUNCH_ANGLE_DEG =
       new LoggedTunableNumber("Aiming/targetPassLaunchAngleDeg", 61.0);
 

--- a/src/main/java/frc/robot/aiming/AimingService.java
+++ b/src/main/java/frc/robot/aiming/AimingService.java
@@ -57,6 +57,7 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
   private double smoothedTurretDeg = 0.0;
   private double smoothedHoodDeg = 0.0;
   private boolean emaInitialized = false;
+  private boolean usingFarAngle = false;
 
   public static final BallTrajectorySim trajectorySim = new BallTrajectorySim();
 
@@ -164,11 +165,23 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
     double vRadial = turretVelocity.getX() * ux + turretVelocity.getY() * uy;
     double vTangential = -turretVelocity.getX() * uy + turretVelocity.getY() * ux;
 
-    double fieldLaunchAngle =
-        Math.toRadians(
-            currentTarget == AimingTarget.HUB
-                ? AimingConstants.TARGET_LAUNCH_ANGLE_DEG.get()
-                : AimingConstants.TARGET_PASS_LAUNCH_ANGLE_DEG.get());
+    double launchAngleDeg;
+    if (currentTarget == AimingTarget.HUB) {
+      double threshold = AimingConstants.FAR_DISTANCE_THRESHOLD_M.get();
+      double hysteresis = AimingConstants.FAR_DISTANCE_HYSTERESIS_M.get();
+      if (usingFarAngle) {
+        usingFarAngle = horizontalDistance > (threshold - hysteresis);
+      } else {
+        usingFarAngle = horizontalDistance > (threshold + hysteresis);
+      }
+      launchAngleDeg =
+          usingFarAngle
+              ? AimingConstants.TARGET_FAR_LAUNCH_ANGLE_DEG.get()
+              : AimingConstants.TARGET_LAUNCH_ANGLE_DEG.get();
+    } else {
+      launchAngleDeg = AimingConstants.TARGET_PASS_LAUNCH_ANGLE_DEG.get();
+    }
+    double fieldLaunchAngle = Math.toRadians(launchAngleDeg);
     double tanTheta = Math.tan(fieldLaunchAngle);
     double cosTheta = Math.cos(fieldLaunchAngle);
     double denominator = horizontalDistance * tanTheta - verticalDistance;


### PR DESCRIPTION
## Summary
- Adds a flatter launch angle (65°) for hub scoring at distances >3.5m where the shooter can't reach the velocity needed for the standard 71° angle
- Includes hysteresis (±0.3m deadband) around the distance threshold to prevent angle jittering
- All parameters (`targetFarLaunchAngleDeg`, `farDistanceThresholdM`, `farDistanceHysteresisM`) are tunable via SmartDashboard

## Test plan
- [ ] Verify in sim that angle switches from 71° to 65° when moving beyond ~3.8m from hub
- [ ] Verify angle switches back to 71° when moving closer than ~3.2m
- [ ] Confirm no jittering when hovering around 3.5m
- [ ] Test tuning values live via SmartDashboard
- [ ] Validate on real robot that far shots are achievable with the lower angle

🤖 Generated with [Claude Code](https://claude.com/claude-code)