### PR TITLE
Add intake agitation when shooting while stationary

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -189,7 +189,7 @@ public class RobotContainer {
                 new ModuleIOTalonFX(TunerConstants.BackRight),
                 (robotPose) -> {});
         aimingService = new AimingService(drive::getLatestSnapshot);
-        driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose);
+        driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose, drive::getChassisSpeeds);
         intake = new IntakeSubsystem(new IntakeIOTalonFX(1, 2, 3, upperCanbus));
         // intake = new IntakeSubsystem(new IntakeIO() {});
 
@@ -263,7 +263,7 @@ public class RobotContainer {
                     frontLeftForwardCamera, robotToFrontLeftForwardCamera, drive::getPose),
                 new VisionIOPhotonVisionSim(backLeftCamera, robotToBackLeftCamera, drive::getPose));
         aimingService = new AimingService(drive::getLatestSnapshot);
-        driveZoneTracker = new DriveZoneTracker(drive::getPose);
+        driveZoneTracker = new DriveZoneTracker(drive::getPose, drive::getChassisSpeeds);
         intake = new IntakeSubsystem(new IntakeIOSim(driveSimulation));
         indexer = new IndexerSubsystem(new IndexerIOSim());
         climber =
@@ -302,7 +302,7 @@ public class RobotContainer {
                 new VisionIO() {},
                 new VisionIO() {});
         aimingService = new AimingService(drive::getLatestSnapshot);
-        driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose);
+        driveZoneTracker = new DriveZoneTracker(drive::getAutoAlignPose, drive::getChassisSpeeds);
         intake = new IntakeSubsystem(new IntakeIO() {});
         indexer = new IndexerSubsystem(new IndexerIO() {});
         climber = new ClimberSubsystem(new ClimberIO() {});

--- a/src/main/java/frc/robot/subsystems/drive/DriveEvents.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveEvents.java
@@ -6,4 +6,6 @@ public interface DriveEvents {
   Trigger isInNeutralZone();
 
   Trigger isOnUpperFieldHalf();
+
+  Trigger isNotMoving();
 }

--- a/src/main/java/frc/robot/subsystems/drive/DriveZoneTracker.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveZoneTracker.java
@@ -1,8 +1,10 @@
 package frc.robot.subsystems.drive;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.FieldConstants;
+import frc.robot.util.LoggedTunableNumber;
 import frc.robot.util.VirtualSubsystem;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
@@ -10,14 +12,21 @@ import org.littletonrobotics.junction.Logger;
 public class DriveZoneTracker extends VirtualSubsystem implements DriveEvents {
 
   private final Supplier<Pose2d> poseSupplier;
+  private final Supplier<ChassisSpeeds> speedsSupplier;
   private boolean inNeutralZone = false;
   private boolean onUpperFieldHalf = false;
+  private boolean notMoving = false;
+
+  private static final LoggedTunableNumber notMovingThreshold =
+      new LoggedTunableNumber("Drive/notMovingThresholdMps", 0.1);
 
   private final Trigger inNeutralZoneTrigger = new Trigger(() -> inNeutralZone);
   private final Trigger onUpperFieldHalfTrigger = new Trigger(() -> onUpperFieldHalf);
+  private final Trigger notMovingTrigger = new Trigger(() -> notMoving);
 
-  public DriveZoneTracker(Supplier<Pose2d> poseSupplier) {
+  public DriveZoneTracker(Supplier<Pose2d> poseSupplier, Supplier<ChassisSpeeds> speedsSupplier) {
     this.poseSupplier = poseSupplier;
+    this.speedsSupplier = speedsSupplier;
   }
 
   @Override
@@ -31,8 +40,13 @@ public class DriveZoneTracker extends VirtualSubsystem implements DriveEvents {
             && x <= FieldConstants.LinesVertical.neutralZoneFar;
     onUpperFieldHalf = y > FieldConstants.LinesHorizontal.center;
 
+    ChassisSpeeds speeds = speedsSupplier.get();
+    double linearSpeed = Math.hypot(speeds.vxMetersPerSecond, speeds.vyMetersPerSecond);
+    notMoving = linearSpeed < notMovingThreshold.get();
+
     Logger.recordOutput("DriveZone/InNeutralZone", inNeutralZone);
     Logger.recordOutput("DriveZone/OnUpperFieldHalf", onUpperFieldHalf);
+    Logger.recordOutput("DriveZone/NotMoving", notMoving);
   }
 
   @Override
@@ -43,5 +57,10 @@ public class DriveZoneTracker extends VirtualSubsystem implements DriveEvents {
   @Override
   public Trigger isOnUpperFieldHalf() {
     return onUpperFieldHalfTrigger;
+  }
+
+  @Override
+  public Trigger isNotMoving() {
+    return notMovingTrigger;
   }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeBehavior.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeBehavior.java
@@ -17,7 +17,16 @@ public class IntakeBehavior extends SubsystemBehavior {
     events.goals().isIdleTrigger().whileTrue(this.intake.idleCommand());
     events.goals().isOuttakingTrigger().whileTrue(this.intake.outtakeCommand());
     events.goals().isIntakingTrigger().whileTrue(this.intake.intakeCommand());
-    events.goals().isShootingTrigger().whileTrue(this.intake.shootingCommand());
+    events
+        .goals()
+        .isShootingTrigger()
+        .and(events.drive().isNotMoving().negate())
+        .whileTrue(this.intake.shootingCommand());
+    events
+        .goals()
+        .isShootingTrigger()
+        .and(events.drive().isNotMoving())
+        .whileTrue(this.intake.agitateCommand());
     events.goals().isPassingTrigger().whileTrue(this.intake.idleCommand());
     events.goals().isRaisedIntakeTrigger().whileTrue(this.intake.raisedCommand());
     events.goals().isClimbingL0().whileTrue(this.intake.idleCommand());

--- a/src/main/java/frc/robot/subsystems/intake/IntakeState.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeState.java
@@ -6,5 +6,6 @@ public enum IntakeState {
   INTAKING,
   OUTTAKING,
   SHOOTING,
-  RAISED
+  RAISED,
+  AGITATING
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -212,7 +212,7 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         // TODO add a up state for when not intaking and not outtaking
         break;
       case AGITATING:
-        m_IO.setRollerTargetSpeed(RPM.of(0.0));
+        m_IO.stop();
         updateAgitation();
         break;
     }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -10,6 +10,7 @@ import static edu.wpi.first.units.Units.Fahrenheit;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Volts;
 
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -46,6 +47,23 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
       new LoggedTunableNumber("Intake/intakeExtenderTargetAngleDown", 0.0);
   private final EnumState<IntakeState> currentGoal =
       new EnumState<>("Intake/States", IntakeState.IDLE);
+
+  // Agitation tunables
+  private static final LoggedTunableNumber agitateDownAngle =
+      new LoggedTunableNumber("Intake/agitateDownAngle", 20.0);
+  private static final LoggedTunableNumber agitateUpAngle =
+      new LoggedTunableNumber("Intake/agitateUpAngle", 60.0);
+  private static final LoggedTunableNumber agitateMaxVelocity =
+      new LoggedTunableNumber("Intake/agitateMaxVelocityDegPerSec", 200.0);
+  private static final LoggedTunableNumber agitateMaxAcceleration =
+      new LoggedTunableNumber("Intake/agitateMaxAccelDegPerSec2", 400.0);
+  private static final double AGITATE_POSITION_TOLERANCE_DEG = 2.0;
+
+  // Agitation state
+  private TrapezoidProfile agitateProfile;
+  private TrapezoidProfile.State agitateCurrentState = new TrapezoidProfile.State(0, 0);
+  private double agitateGoalPosition;
+  private boolean agitateInitialized = false;
 
   public LoggedTunableGainsBuilder rollerGains =
       new LoggedTunableGainsBuilder(
@@ -129,6 +147,13 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         });
   }
 
+  public Command agitateCommand() {
+    return runOnce(
+        () -> {
+          currentGoal.set(IntakeState.AGITATING);
+        });
+  }
+
   public void setTestingState() {
     currentGoal.set(IntakeState.TESTING);
   }
@@ -151,6 +176,7 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         }
         // NO break; on purpose
       case INTAKING:
+        agitateInitialized = false;
         m_IO.setRollerTargetSpeed(RPM.of(intakeTargetRPM.get()));
         m_IO.setExtenderTargetAngle(Degrees.of(intakeExtenderTargetAngleDown.get()));
         if (Constants.currentMode == Constants.Mode.SIM) {
@@ -161,6 +187,7 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         }
         break;
       case OUTTAKING:
+        agitateInitialized = false;
         m_IO.setRollerTargetSpeed(RPM.of(-intakeTargetRPM.get()));
         m_IO.setExtenderTargetAngle(Degrees.of(intakeExtenderTargetAngleDown.get()));
         if (Constants.currentMode == Constants.Mode.SIM) {
@@ -175,6 +202,7 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         }
         break;
       case IDLE:
+        agitateInitialized = false;
         stop();
         if (Constants.currentMode == Constants.Mode.SIM) {
           AimingService.trajectorySim.setSpawnFuelOnGround(false);
@@ -183,9 +211,42 @@ public class IntakeSubsystem extends SubsystemBase implements IntakeEvents {
         // m_IO.setExtenderTargetAngle(Degrees.of(intakeExtenderTargetAngleUp.get()));
         // TODO add a up state for when not intaking and not outtaking
         break;
+      case AGITATING:
+        m_IO.setRollerTargetSpeed(RPM.of(0.0));
+        updateAgitation();
+        break;
     }
     rollerGains.ifGainsHaveChanged((gains) -> this.m_IO.setRollerGains(gains));
     extenderGains.ifGainsHaveChanged((gains) -> this.m_IO.setExtenderGains(gains));
+  }
+
+  private void updateAgitation() {
+    if (!agitateInitialized) {
+      agitateProfile =
+          new TrapezoidProfile(
+              new TrapezoidProfile.Constraints(
+                  agitateMaxVelocity.get(), agitateMaxAcceleration.get()));
+      agitateCurrentState = new TrapezoidProfile.State(logged.extenderAngle.in(Degrees), 0);
+      agitateGoalPosition = agitateDownAngle.get();
+      agitateInitialized = true;
+    }
+
+    TrapezoidProfile.State goal = new TrapezoidProfile.State(agitateGoalPosition, 0);
+    agitateCurrentState = agitateProfile.calculate(0.020, agitateCurrentState, goal);
+
+    m_IO.setExtenderTargetAngle(Degrees.of(agitateCurrentState.position));
+
+    if (Math.abs(agitateCurrentState.position - agitateGoalPosition)
+        < AGITATE_POSITION_TOLERANCE_DEG) {
+      if (agitateGoalPosition == agitateDownAngle.get()) {
+        agitateGoalPosition = agitateUpAngle.get();
+      } else {
+        agitateGoalPosition = agitateDownAngle.get();
+      }
+    }
+
+    Logger.recordOutput("Intake/AgitateSetpoint", agitateCurrentState.position);
+    Logger.recordOutput("Intake/AgitateGoal", agitateGoalPosition);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- When shooting and not moving, the intake extender oscillates between tunable angles (20-60 deg) using a WPILib TrapezoidProfile for smooth motion, with rollers OFF
- When shooting and moving, existing behavior is preserved (extender down, rollers ON)
- Adds `isNotMoving()` trigger to DriveZoneTracker using ChassisSpeeds with tunable threshold (0.1 m/s default)

## Changes
- `IntakeState` - Added `AGITATING` enum value
- `DriveEvents` / `DriveZoneTracker` - Added `isNotMoving()` trigger with tunable speed threshold
- `IntakeSubsystem` - TrapezoidProfile-based agitation with tunables for angles, velocity (200 deg/s), acceleration (400 deg/s²)
- `IntakeBehavior` - Split shooting trigger: `shooting + notMoving → agitate`, `shooting + moving → shoot`
- `RobotContainer` - Updated DriveZoneTracker constructors with ChassisSpeeds supplier

## Test plan
- [ ] Verify agitation oscillation in simulation (check Intake/AgitateSetpoint and Intake/AgitateGoal logs)
- [ ] Confirm rollers are OFF during agitation (RPM = 0)
- [ ] Confirm normal shooting behavior when robot is moving
- [ ] Tune agitate angles, velocity, and acceleration via SmartDashboard
- [ ] Verify notMoving threshold works correctly at competition speeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)