### PR TITLE
Improve shoot-on-the-move accuracy during rotation

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -421,7 +421,7 @@ public class RobotContainer {
             drive,
             () -> -controller.getLeftY() * drive.getEffectiveSpeedLimit(),
             () -> -controller.getLeftX() * drive.getEffectiveSpeedLimit(),
-            () -> -controller.getRightX() * REG_ANGULAR_SPEED));
+            () -> -controller.getRightX() * REG_ANGULAR_SPEED * drive.getEffectiveSpeedLimit()));
 
     // Switch to X pattern when X button is pressed
     controller.x().onTrue(Commands.runOnce(drive::stopWithX, drive));

--- a/src/main/java/frc/robot/aiming/AimingService.java
+++ b/src/main/java/frc/robot/aiming/AimingService.java
@@ -48,9 +48,9 @@ public class AimingService extends VirtualSubsystem implements AimingEvents {
   private static final LoggedTunableNumber rpmEmaAlpha =
       new LoggedTunableNumber("Aiming/Smoothing/rpmEmaAlpha", 0.08);
   private static final LoggedTunableNumber turretEmaAlpha =
-      new LoggedTunableNumber("Aiming/Smoothing/turretEmaAlpha", 0.15);
+      new LoggedTunableNumber("Aiming/Smoothing/turretEmaAlpha", 1.0);
   private static final LoggedTunableNumber hoodEmaAlpha =
-      new LoggedTunableNumber("Aiming/Smoothing/hoodEmaAlpha", 0.10);
+      new LoggedTunableNumber("Aiming/Smoothing/hoodEmaAlpha", 0.75);
 
   // EMA state (only written by AimingThread, no synchronization needed)
   private double smoothedRPM = 0.0;


### PR DESCRIPTION
## Summary
- Apply goal-based speed limit to angular velocity joystick input during shooting, matching existing linear velocity limiting. Previously the driver could command full rotational speed while shooting, destabilizing the aiming solution.
- Increase turret EMA alpha from 0.15 → 1.0 (no filtering) to eliminate tracking lag during rotation. At 0.15, the turret setpoint lagged ~6.5° behind during typical rotation speeds.
- Increase hood EMA alpha from 0.10 → 0.75 for faster hood tracking. RPM alpha unchanged at 0.08 to prevent flywheel jitter.

## Test plan
- [ ] Verify shooting accuracy while stationary is unchanged
- [ ] Test shoot-on-the-move while translating — should be same or better
- [ ] Test shoot-on-the-move while rotating — should be significantly improved
- [ ] Verify turret setpoint isn't excessively noisy with alpha=1.0 (tune via SmartDashboard `Aiming/Smoothing/turretEmaAlpha` if needed)
- [ ] Verify hood isn't jittery at 0.75 alpha
- [ ] Confirm slow button still limits both linear and angular speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)