### PR TITLE
Gate indexer on shooter RPM tolerance

### DIFF
--- a/src/main/java/frc/robot/subsystems/indexer/IndexerBehavior.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerBehavior.java
@@ -20,6 +20,7 @@ public class IndexerBehavior extends SubsystemBehavior {
         .goals()
         .isShootingTrigger()
         .and(events.turret().isInToleranceTrigger())
+        .and(events.shooter().isInToleranceTrigger())
         .whileTrue(indexer.indexingCommand())
         .whileFalse(indexer.idleCommand());
   }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterEvents.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterEvents.java
@@ -7,4 +7,6 @@ public interface ShooterEvents {
   public Trigger isIdleTrigger();
 
   public Trigger isShootingTrigger();
+
+  public Trigger isInToleranceTrigger();
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -18,6 +18,8 @@ import org.littletonrobotics.junction.Logger;
 public class ShooterSubsystem extends SubsystemBase implements ShooterEvents {
   private final ShooterIO m_IO;
   private final LoggedTunableNumber setpoint = new LoggedTunableNumber("Shooter/setpoint", 2500);
+  private final LoggedTunableNumber tolerancePercent =
+      new LoggedTunableNumber("Shooter/TolerancePercent", 0.5);
   private volatile boolean shouldThreadCommand = false;
 
   private final EnumState<ShooterState> m_state =
@@ -117,6 +119,20 @@ public class ShooterSubsystem extends SubsystemBase implements ShooterEvents {
   @Override
   public Trigger isShootingTrigger() {
     return m_state.is(ShooterState.SHOOTING);
+  }
+
+  @Override
+  public Trigger isInToleranceTrigger() {
+    return new Trigger(() -> isShooterInTolerance());
+  }
+
+  private boolean isShooterInTolerance() {
+    double currentRPM = logged.shooterAngularVelocity.in(RPM);
+    double setpointRPM = logged.shooterSetpoint.in(RPM);
+    if (setpointRPM <= 0) {
+      return false;
+    }
+    return currentRPM >= setpointRPM * tolerancePercent.getAsDouble();
   }
 
   public Command getNewSetShooterSpeedCommand(DoubleSupplier speed) {


### PR DESCRIPTION
## Summary
- Add `isInToleranceTrigger()` to `ShooterEvents` / `ShooterSubsystem`, matching the existing turret tolerance pattern
- Indexer now requires shooter RPM >= 50% of setpoint before feeding the ball
- Tolerance is tunable via SmartDashboard (`Shooter/TolerancePercent`, default 0.5)

## Test plan
- [ ] Verify indexer does not feed until flywheel is spun up
- [ ] Verify no delay in feeding once flywheel is at speed
- [ ] Tune `Shooter/TolerancePercent` on real robot — 50% may be too conservative or too aggressive
- [ ] Verify auto shooting still works with the added gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)